### PR TITLE
use Test::Requires to test for minimum version, rather than a bare eval.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,8 @@
 Revision history for Dist-Zilla-Plugin-Test-Version
+
+{{$NEXT{
+        - use Test::Requires rather than an eval.
+
 0.1.3     2011-07-23
 
 0.1.2     2011-06-02

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -28,6 +28,7 @@ my %WriteMakefileArgs = (
     'Dist::Zilla::Plugin::InlineFiles' => '0',
     'Moose' => '0',
     'Test::Version' => '0.04'
+    'Test::Requires' => '0',
   },
   'VERSION' => '0.1.3',
   'test' => {

--- a/lib/Dist/Zilla/Plugin/Test/Version.pm
+++ b/lib/Dist/Zilla/Plugin/Test/Version.pm
@@ -59,9 +59,9 @@ use strict;
 use warnings;
 use Test::More;
 
-eval "use Test::Version 0.04";
-plan skip_all => "Test::Version 0.04 required for testing versions"
-    if $@;
+use Test::Requires {
+    'Test::Version' => 0.04,
+};
 
 version_all_ok();
 done_testing;


### PR DESCRIPTION
self-explanatory.  This is exactly what Test::Requires is for, and every time someone tests $@ explicitly, somewhere a kitten dies.
